### PR TITLE
Reduce player immunity to 0.8 seconds

### DIFF
--- a/scene/Player.tscn
+++ b/scene/Player.tscn
@@ -60,7 +60,7 @@ shape = SubResource( 3 )
 stream = ExtResource( 7 )
 
 [node name="ImmunityTimer" type="Timer" parent="."]
-wait_time = 2.0
+wait_time = 0.8
 one_shot = true
 
 [node name="Reject" parent="." instance=ExtResource( 8 )]


### PR DESCRIPTION
It is the same amount of time it takes for a zombie to move, so it should be enough time to get out of the way.

Fixes #70.