### PR TITLE
Remove hack for Player health change

### DIFF
--- a/scene/GameGrid.gd
+++ b/scene/GameGrid.gd
@@ -148,9 +148,6 @@ func _on_Zombie_tree_exiting() -> void:
 
 
 func _on_Player_health_change(lives: int) -> void:
-	if not started:
-		yield(self, "started")
-
 	info_ref.display_lives(lives)
 
 	if lives <= 0:


### PR DESCRIPTION
It used to be that the game would crash when the Player had its initial health set. This is no longer the case.