### PR TITLE
Simplify Player kill() function

### DIFF
--- a/scene/Player.gd
+++ b/scene/Player.gd
@@ -99,12 +99,11 @@ func _set_dir(dir: int) -> void:
 
 
 func kill() -> void:
-	while exists and lives > 0:
+	if exists and lives > 0:
 		if is_immortal():
 			toggle_immortality()
 
-		damage()
-		yield($ImmunityTimer, "timeout")
+		set_lives(0)
 
 
 func _handle_action() -> void:


### PR DESCRIPTION
Attempt to fix #215, since that issue was triggered when killing off the player using the kill player cheat while also getting damaged by enemies. As well, since the set_lives() function was introduced, setting the player's health to zero is less hacky.